### PR TITLE
ショートカット設定ローダーのタイプミスを修正

### DIFF
--- a/AEIOU/WindowsFormsApplication1/KeyBinds.cs
+++ b/AEIOU/WindowsFormsApplication1/KeyBinds.cs
@@ -101,8 +101,8 @@ namespace AEIOU
             KaraCellNoMove = getInnerText("karaCellNoMove", doc.SelectNodes("/document/pref/shortcuts/karaCellNoMove"));
             InputSheetSec = getInnerText("inputSheetSec", doc.SelectNodes("/document/pref/shortcuts/inputSheetSec"));
             SetSheetDiv4 = getInnerText("setSheetDiv4", doc.SelectNodes("/document/pref/shortcuts/setSheetDiv4"));
-            SetSheetDiv6 = getInnerText("setSheetDiv4", doc.SelectNodes("/document/pref/shortcuts/setSheetDiv6"));
-            SetSheetDiv12 = getInnerText("setSheetDiv4", doc.SelectNodes("/document/pref/shortcuts/setSheetDiv12"));
+            SetSheetDiv6 = getInnerText("setSheetDiv6", doc.SelectNodes("/document/pref/shortcuts/setSheetDiv6"));
+            SetSheetDiv12 = getInnerText("setSheetDiv12", doc.SelectNodes("/document/pref/shortcuts/setSheetDiv12"));
             StayOnTop = getInnerText("stayOnTop", doc.SelectNodes("/document/pref/shortcuts/stayOnTop"));
             AutoAdjust = getInnerText("autoAdjust", doc.SelectNodes("/document/pref/shortcuts/autoAdjust"));
             DisplayFrameNumber = getInnerText("displayFrameNumber", doc.SelectNodes("/document/pref/shortcuts/displayFrameNumber"));


### PR DESCRIPTION
## Summary
- fix copy-paste typo for SetSheetDiv6 and SetSheetDiv12 in `KeyBinds.loadShortcutsSetting`

## Testing
- `apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6879ef8eaf6c83229dcc1f20518a65b7